### PR TITLE
購入済み商品情報をコンポーネント化

### DIFF
--- a/src/components/PurchasedEntry.vue
+++ b/src/components/PurchasedEntry.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { convertToYen } from '@/utils/priceFormatter';
+import { formatDate } from '@/utils/dateFormatter';
+import type { PurchasedProductEntry } from '@/interfaces/ProductEntry';
+import type { PurchaseHistory } from '@/interfaces/PurchaseHistoryRepositoryInterface';
+
+const props = defineProps<{
+  productEntry: PurchasedProductEntry;
+  purchaseHistory: PurchaseHistory;
+}>();
+
+const emit = defineEmits<{
+  (e: 'cancelProduct', historyId: number, productEntry: PurchasedProductEntry): void;
+}>();
+
+const isDeleted = computed(() => props.productEntry.deletedAt !== null);
+const unitPrice = computed(() => 
+  convertToYen(props.productEntry.product.price, props.purchaseHistory.rate).toLocaleString()
+);
+const canceledAt = computed(() =>
+  props.productEntry.deletedAt ? formatDate(props.productEntry.deletedAt) : ''
+);
+
+const handleCancelProductClick = (historyId: number, productEntry: PurchasedProductEntry) => {
+  if (isDeleted.value) return;
+  emit('cancelProduct', historyId, productEntry);
+};
+</script>
+
+<template>
+  <p>商品名:{{ productEntry.product.title }}</p>
+  <p>単価:{{ unitPrice }}円</p>
+  <p>購入個数:{{ productEntry.quantity }}個</p>
+  <p v-if="isDeleted">キャンセル日時:{{ canceledAt }}</p>
+  <button v-if="!isDeleted" @click="handleCancelProductClick(purchaseHistory.id, productEntry)">購入キャンセル</button>
+</template>

--- a/src/components/PurchasedEntry.vue
+++ b/src/components/PurchasedEntry.vue
@@ -22,9 +22,9 @@ const canceledAt = computed(() =>
   props.productEntry.deletedAt ? formatDate(props.productEntry.deletedAt) : ''
 );
 
-const handleCancelProductClick = (historyId: number, productEntry: PurchasedProductEntry) => {
+const handleCancelProductClick = () => {
   if (isDeleted.value) return;
-  emit('cancelProduct', historyId, productEntry);
+  emit('cancelProduct', props.purchaseHistory.id, props.productEntry);
 };
 </script>
 
@@ -33,5 +33,5 @@ const handleCancelProductClick = (historyId: number, productEntry: PurchasedProd
   <p>単価:{{ unitPrice }}円</p>
   <p>購入個数:{{ productEntry.quantity }}個</p>
   <p v-if="isDeleted">キャンセル日時:{{ canceledAt }}</p>
-  <button v-if="!isDeleted" @click="handleCancelProductClick(purchaseHistory.id, productEntry)">購入キャンセル</button>
+  <button v-if="!isDeleted" @click="handleCancelProductClick()">購入キャンセル</button>
 </template>

--- a/src/views/PurchaseHistoryView.vue
+++ b/src/views/PurchaseHistoryView.vue
@@ -4,6 +4,7 @@ import { LocalStoragePurchaseHistoryRepository } from '@/repositories/LocalStora
 import { usePurchaseHistoryStore } from '@/stores/UsePurchaseHistoryStore';
 import { convertToYen } from '@/utils/priceFormatter';
 import { formatDate } from '@/utils/dateFormatter';
+import PurchasedEntry from '@/components/PurchasedEntry.vue';
 import type { PurchaseHistory, PurchaseHistoryRepositoryInterface } from '@/interfaces/PurchaseHistoryRepositoryInterface';
 import type { PurchasedProductEntry } from '@/interfaces/ProductEntry';
 
@@ -61,11 +62,11 @@ const displayedHistories = computed<Array<PurchaseHistory>>(() => {
         <p>購入商品:</p>
         <ul>
           <li v-for="productEntry in purchaseHistory.productOrders" :key="productEntry.id">
-            <p>商品名:{{ productEntry.product.title }}</p>
-            <p>単価:{{ convertToYen(productEntry.product.price, purchaseHistory.rate).toLocaleString() }}円</p>
-            <p>購入個数:{{ productEntry.quantity }}個</p>
-            <p v-if="productEntry.deletedAt">キャンセル日時:{{ formatDate(productEntry.deletedAt) }}</p>
-            <button v-if="productEntry.deletedAt === null" @click="handleCancelProductClick(purchaseHistory.id, productEntry)">購入キャンセル</button>
+            <PurchasedEntry
+              :productEntry="productEntry"
+              :purchaseHistory="purchaseHistory"
+              @cancelProduct="handleCancelProductClick"
+            />
           </li>
         </ul>
         <div class="border"></div>


### PR DESCRIPTION
## 変更点

- 購入した商品履歴の情報表示内容をコンポーネント化した
- キャンセル商品か否かをcomputedを使って表示を切り替えた
- テンプレート内で整形していた単価やキャンセル日時もcomputedを用いるように修正した

参考課題：https://github.com/ult-sohtome/shopping-site/pull/11#discussion_r2103911424