### PR TITLE
商品取得処理用のスタブAPIの実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # 翻訳スタブを使うかどうか（true or false）
 VITE_USE_TRANSLATE_STUB=
+# 商品スタブを使うかどうか（true or false）
+VITE_DEFAULT_USE_PRODUCT_STUB=

--- a/docs/build-environment.md
+++ b/docs/build-environment.md
@@ -7,6 +7,7 @@
 ## 開発環境構築手順
 
 1. リポジトリをクローンする
+
 2. パッケージをインストールする
 
     ```shell
@@ -14,17 +15,25 @@
     cd server
     npm install
     ```
-3. `.env`ファイルを`/server`に作成する
-   - `.env.example`ファイルを参考に、プロジェクト直下に`.env`ファイルを作成する
+
+3. `.env`ファイルを作成する
+    - `.env.example`ファイルを参考に、プロジェクト直下に`.env`ファイルを作成する
+    - 翻訳スタブを使うか否か`true`または`false`を記述する
+    - 商品スタブを使うか否かの初期値として`true`または`false`を記述する
+
+4. 翻訳用サーバーの`.env`ファイルを`/server`に作成する
+   - `.env.example`ファイルを参考に、`/server`配下に`.env`ファイルを作成する
    - PROXYを使用する場合：アドレスを記入し`USE_PROXY`を`true`にする
    - PROXYを使用しない場合：`USE_PROXY`を`false`にする
-4. 翻訳用サーバーを起動する
+
+5. 翻訳用サーバーを起動する
 
     ```shell
     cd server
     node server.js
     ```
-5. ローカルサーバーを起動する
+
+6. ローカルサーバーを起動する
 
     ```shell
     npm run dev

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@ import { onMounted } from 'vue'
 import type { PurchaseHistoryRepositoryInterface } from './interfaces/PurchaseHistoryRepositoryInterface'
 import { LocalStoragePurchaseHistoryRepository } from '@/repositories/LocalStoragePurchaseHistoryRepository'
 import { usePurchaseHistoryStore } from './stores/UsePurchaseHistoryStore'
+import { useProductRepositoryStore } from './stores/UseProductRepositoryStore'
 import { runMigrations } from './migrations/runMigrations'
 
 const props = withDefaults(defineProps<{
@@ -13,6 +14,7 @@ const props = withDefaults(defineProps<{
 });
 
 const purchaseHistoryStore = usePurchaseHistoryStore();
+const repositoryStore = useProductRepositoryStore();
 
 onMounted(() => {
   runMigrations(props.purchaseHistoryRepository);
@@ -29,6 +31,9 @@ onMounted(() => {
         <RouterLink to="/purchase-history">購入履歴</RouterLink>
       </nav>
     </div>
+    <button @click="repositoryStore.toggleProductRepository">
+      {{ repositoryStore.isUseStub ? '本番商品APIに切り替え' : '商品スタブに切り替え' }}
+    </button>
   </header>
 
   <RouterView />

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,6 @@ import { onMounted } from 'vue'
 import type { PurchaseHistoryRepositoryInterface } from './interfaces/PurchaseHistoryRepositoryInterface'
 import { LocalStoragePurchaseHistoryRepository } from '@/repositories/LocalStoragePurchaseHistoryRepository'
 import { usePurchaseHistoryStore } from './stores/UsePurchaseHistoryStore'
-import { useProductRepositoryStore } from './stores/UseProductRepositoryStore'
 import { runMigrations } from './migrations/runMigrations'
 
 const props = withDefaults(defineProps<{
@@ -14,7 +13,6 @@ const props = withDefaults(defineProps<{
 });
 
 const purchaseHistoryStore = usePurchaseHistoryStore();
-const repositoryStore = useProductRepositoryStore();
 
 onMounted(() => {
   runMigrations(props.purchaseHistoryRepository);
@@ -31,9 +29,6 @@ onMounted(() => {
         <RouterLink to="/purchase-history">購入履歴</RouterLink>
       </nav>
     </div>
-    <button @click="repositoryStore.toggleProductRepository">
-      {{ repositoryStore.isUseStub ? '本番商品APIに切り替え' : '商品スタブに切り替え' }}
-    </button>
   </header>
 
   <RouterView />

--- a/src/components/commom/ConfirmDialog.vue
+++ b/src/components/commom/ConfirmDialog.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+const props = defineProps<{
+  isDialogVisible: boolean,
+  dialogMessage: string
+}>();
+const emit = defineEmits<{
+  (event: 'confirm'): void;
+  (event: 'cancel'): void;
+}>();
+
+const handleConfirm = () => emit('confirm');
+const handleCancel = () => emit('cancel');
+</script>
+
+<template>
+  <div v-if="isDialogVisible" class="dialog">
+    <div class="dialog-content">
+      <p>{{ dialogMessage }}</p>
+      <div class="actions">
+        <button class="confirm-button" @click="handleConfirm">実行</button>
+        <button class="cancel-button" @click="handleCancel">キャンセル</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+.dialog-content {
+  background-color: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+.actions {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+.confirm-button {
+  margin-top: 10px;
+  padding: 8px 16px;
+  background-color: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.confirm-button:hover {
+  background-color: #347937;
+}
+.cancel-button {
+  margin-top: 10px;
+  padding: 8px 16px;
+  background-color: #b1b1b1;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.cancel-button:hover {
+  background-color: #8c8c8c;
+}
+</style>

--- a/src/factories/productRepositoryFactory.ts
+++ b/src/factories/productRepositoryFactory.ts
@@ -1,10 +1,12 @@
 import { ApiProductRepository } from '@/repositories/ApiProductRepository';
 import { StubProductRepository } from '@/repositories/StubProductRepository';
 import type { ProductRepositoryInterface } from '@/interfaces/ProductRepositoryInterface';
+import { useProductRepositoryStore } from '@/stores/UseProductRepositoryStore';
 
 export function createProductRepository(): ProductRepositoryInterface {
-  const isUseStub: boolean = import.meta.env.VITE_USE_PRODUCT_STUB === 'true';
-  return isUseStub
+  const productRepositoryStore = useProductRepositoryStore();
+
+  return productRepositoryStore.isUseStub
     ? new StubProductRepository()
     : new ApiProductRepository();
 }

--- a/src/factories/productRepositoryFactory.ts
+++ b/src/factories/productRepositoryFactory.ts
@@ -1,12 +1,9 @@
 import { ApiProductRepository } from '@/repositories/ApiProductRepository';
 import { StubProductRepository } from '@/repositories/StubProductRepository';
 import type { ProductRepositoryInterface } from '@/interfaces/ProductRepositoryInterface';
-import { useProductRepositoryStore } from '@/stores/UseProductRepositoryStore';
 
-export function createProductRepository(): ProductRepositoryInterface {
-  const productRepositoryStore = useProductRepositoryStore();
-
-  return productRepositoryStore.isUseStub
+export function createProductRepository(isUseStub: boolean): ProductRepositoryInterface {
+  return isUseStub
     ? new StubProductRepository()
     : new ApiProductRepository();
 }

--- a/src/factories/productRepositoryFactory.ts
+++ b/src/factories/productRepositoryFactory.ts
@@ -1,0 +1,10 @@
+import { ApiProductRepository } from '@/repositories/ApiProductRepository';
+import { StubProductRepository } from '@/repositories/StubProductRepository';
+import type { ProductRepositoryInterface } from '@/interfaces/ProductRepositoryInterface';
+
+export function createProductRepository(): ProductRepositoryInterface {
+  const isUseStub: boolean = import.meta.env.VITE_USE_PRODUCT_STUB === 'true';
+  return isUseStub
+    ? new StubProductRepository()
+    : new ApiProductRepository();
+}

--- a/src/factories/translateRepositoryFactory.ts
+++ b/src/factories/translateRepositoryFactory.ts
@@ -1,4 +1,3 @@
-// src/factories/translateRepositoryFactory.ts
 import { ApiTranslateRepository } from '@/repositories/ApiTranslateRepository';
 import { StubTranslateRepository } from '@/repositories/StubTranslateRepository';
 import type { TranslateRepositoryInterface } from '@/interfaces/TranslateRepositoryInterface';

--- a/src/repositories/StubProductRepository.ts
+++ b/src/repositories/StubProductRepository.ts
@@ -1,0 +1,37 @@
+import type { Product, ProductRepositoryInterface } from "@/interfaces/ProductRepositoryInterface";
+
+export class StubProductRepository implements ProductRepositoryInterface {
+  constructor(
+    private shouldFail: boolean = false,
+    private delayMs: number = 1000
+  ) {}
+
+  private readonly products: Array<Product> = [
+    { id: 1, title: "Product 1", price: 10, description: "Description 1", category: "book", image: "image1.jpg" },
+    { id: 2, title: "Product 2", price: 20, description: "Description 2", category: "clothing", image: "image2.jpg" },
+    { id: 3, title: "Product 3", price: 30, description: "Description 3", category: "consumer electronics", image: "image3.jpg" },
+    { id: 4, title: "Product 4", price: 40, description: "Description 4", category: "furniture", image: "image4.jpg" },
+    { id: 5, title: "Product 5", price: 50, description: "Description 5", category: "toys", image: "image5.jpg" }
+  ];
+
+  private async simulateDelay(): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, this.delayMs));
+  }
+
+  async getAllProducts(): Promise<Product[]> {
+    await this.simulateDelay();
+    if (this.shouldFail) {
+      throw new Error('(スタブ)商品データの取得に失敗しました。');
+    }
+    return this.products;
+  }
+
+  async getProductById(id: number): Promise<Product | null> {
+    await this.simulateDelay();
+    if (this.shouldFail) {
+      throw new Error('(スタブ)指定された商品データの取得に失敗しました。');
+    }
+    const product = this.products.find(product => product.id === id);
+    return product || null;
+  }
+}

--- a/src/repositories/StubProductRepository.ts
+++ b/src/repositories/StubProductRepository.ts
@@ -7,11 +7,11 @@ export class StubProductRepository implements ProductRepositoryInterface {
   ) {}
 
   private readonly products: Array<Product> = [
-    { id: 1, title: "Product 1", price: 10, description: "Description 1", category: "book", image: "image1.jpg" },
-    { id: 2, title: "Product 2", price: 20, description: "Description 2", category: "clothing", image: "image2.jpg" },
-    { id: 3, title: "Product 3", price: 30, description: "Description 3", category: "consumer electronics", image: "image3.jpg" },
-    { id: 4, title: "Product 4", price: 40, description: "Description 4", category: "furniture", image: "image4.jpg" },
-    { id: 5, title: "Product 5", price: 50, description: "Description 5", category: "toys", image: "image5.jpg" }
+    { id: 1, title: "Product 1", price: 10, description: "Description 1", category: "book", image: "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEi3BuzxKMDUyDAxJ3uSmOUDoBuAk4PHL6wJ-sbkoWaf0kFhAVGKJyb68UlWudASWVefUbWWJswxOyYVhup-Mesvpq0KORxCwjk8TjojMTjkduxmrZgaJXwg_wjz8YLh6aXfjdxYWEvKCT1_/s538/sports_katsudouryoukei.png" },
+    { id: 2, title: "Product 2", price: 20, description: "Description 2", category: "clothing", image: "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhSyGh8RpLf71mLoVpgbImOme2usyVmWE-Zs3ib-jWCxKp-Ib-ctcvLslI4C4jmsWGTUIgnjHd8myqoo1d-sAmkgprAZfog6yQhnEe4zEbke__Dc2od2IyDVI7jJZncDTE0J7je3NI9hfIC/s618/kaden_oil_heater.png" },
+    { id: 3, title: "Product 3", price: 30, description: "Description 3", category: "consumer electronics", image: "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgv_XVADjx5Cg8ZzzI4XMXLT1o4BDTSrUn5SHOuN8pyRpeEw4uT9KHgHVa_GsteAL6BRJNjRdbE7b3sTxyxJwr72Mis9dLQyWrSYy5cAytdJlcUBQn9KsSr9Vk0R1fv6e-sY31CNQUeBAUR/s536/building_monooki_goya.png" },
+    { id: 4, title: "Product 4", price: 40, description: "Description 4", category: "furniture", image: "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiA-YvxRfcNLdb8pY-pEGV_InKsic41qZ9q-ZkSi4sZozhlYNFzPbcY6UdLIanaBr7WDfQk7b7evjMPBKtJHl5KiMHXvlrVoJAwTIAkSyQMoAGbiuDj5qva6bz86dTnEXSqpYLFyFTyYpCA/s400/beads_cushion_woman.png" },
+    { id: 5, title: "Product 5", price: 50, description: "Description 5", category: "toys", image: "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjvJAfNqzySw89hcgfozrN-qVdpEfHcx_LbG0bAVR5Izahy6UJTyOuSjhnhdOWYKEZto-kuXq99rLmgRCWnIi7po8cS__sxj1wSbP0tO_t0nVCPV2FYxrODJiRiA0u-ctWC_FhyphenhyphenAu3LReuD/s400/game_gaming_chair.png" }
   ];
 
   private async simulateDelay(): Promise<void> {

--- a/src/stores/UseProductRepositoryStore.ts
+++ b/src/stores/UseProductRepositoryStore.ts
@@ -1,20 +1,12 @@
 import { createProductRepository } from '@/factories/productRepositoryFactory';
-import type { ProductRepositoryInterface } from '@/interfaces/ProductRepositoryInterface';
-import { ApiProductRepository } from '@/repositories/ApiProductRepository';
-import { StubProductRepository } from '@/repositories/StubProductRepository';
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 export const useProductRepositoryStore = defineStore('ProductRepository', () => {
-  const isUseStub = ref(import.meta.env.VITE_USE_PRODUCT_STUB === 'true');
-  const productRepository = ref<ProductRepositoryInterface>(createProductRepository());
+  const isUseStub = ref(import.meta.env.VITE_DEFAULT_USE_PRODUCT_STUB === 'true');
+  const productRepository = computed(() => createProductRepository());
 
-  const toggleProductRepository = () => {
-    isUseStub.value = !isUseStub.value;
-    productRepository.value = isUseStub.value
-      ? new StubProductRepository()
-      : new ApiProductRepository();
-  };
+  const toggleProductRepository = () => isUseStub.value = !isUseStub.value;
 
   return {
     isUseStub,

--- a/src/stores/UseProductRepositoryStore.ts
+++ b/src/stores/UseProductRepositoryStore.ts
@@ -1,0 +1,24 @@
+import { createProductRepository } from '@/factories/productRepositoryFactory';
+import type { ProductRepositoryInterface } from '@/interfaces/ProductRepositoryInterface';
+import { ApiProductRepository } from '@/repositories/ApiProductRepository';
+import { StubProductRepository } from '@/repositories/StubProductRepository';
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useProductRepositoryStore = defineStore('ProductRepository', () => {
+  const isUseStub = ref(import.meta.env.VITE_USE_PRODUCT_STUB === 'true');
+  const productRepository = ref<ProductRepositoryInterface>(createProductRepository());
+
+  const toggleProductRepository = () => {
+    isUseStub.value = !isUseStub.value;
+    productRepository.value = isUseStub.value
+      ? new StubProductRepository()
+      : new ApiProductRepository();
+  };
+
+  return {
+    isUseStub,
+    productRepository,
+    toggleProductRepository
+  };
+});

--- a/src/stores/UseProductRepositoryStore.ts
+++ b/src/stores/UseProductRepositoryStore.ts
@@ -4,7 +4,7 @@ import { computed, ref } from 'vue';
 
 export const useProductRepositoryStore = defineStore('ProductRepository', () => {
   const isUseStub = ref(import.meta.env.VITE_DEFAULT_USE_PRODUCT_STUB === 'true');
-  const productRepository = computed(() => createProductRepository());
+  const productRepository = computed(() => createProductRepository(isUseStub.value));
 
   const toggleProductRepository = () => isUseStub.value = !isUseStub.value;
 

--- a/src/views/CartView.vue
+++ b/src/views/CartView.vue
@@ -93,8 +93,7 @@ const props = withDefaults(defineProps<{
     }
   });
 
-  watch(() => [...cartStore.cartItems],updateCartItems,{immediate: true, deep: true});
-  watch(() => productRepositoryStore.productRepository, updateCartItems);
+  watch(() => [...cartStore.cartItems],updateCartItems,{immediate: false, deep: true});
 </script>
 
 <template>

--- a/src/views/CartView.vue
+++ b/src/views/CartView.vue
@@ -1,19 +1,18 @@
 <script setup lang="ts">
-  import { ref, onMounted, computed, watch } from 'vue';
-  import { ApiRateRepository } from '@/repositories/ApiRateRepository';
-  import { ApiTranslateRepository } from '@/repositories/ApiTranslateRepository';
-  import { LocalStoragePurchaseHistoryRepository } from '@/repositories/LocalStoragePurchaseHistoryRepository';
-  import { useRateStore } from '@/stores/UseRateStore';
-  import { convertToYen } from '@/utils/priceFormatter';
-  import { useCartStore } from '@/stores/UseCartStore';
-  import { usePurchaseHistoryStore } from '@/stores/UsePurchaseHistoryStore';
+import { ref, onMounted, computed, watch } from 'vue';
+import { ApiRateRepository } from '@/repositories/ApiRateRepository';
+import { LocalStoragePurchaseHistoryRepository } from '@/repositories/LocalStoragePurchaseHistoryRepository';
+import { useRateStore } from '@/stores/UseRateStore';
+import { convertToYen } from '@/utils/priceFormatter';
+import { useCartStore } from '@/stores/UseCartStore';
+import { usePurchaseHistoryStore } from '@/stores/UsePurchaseHistoryStore';
 import { useProductRepositoryStore } from '@/stores/UseProductRepositoryStore';
 import type { Product } from '@/interfaces/ProductRepositoryInterface';
-  import type { RateRepositoryInterface } from '@/interfaces/RateRepositoryInterface';
-  import type { TranslateRepositoryInterface } from '@/interfaces/TranslateRepositoryInterface';
-  import type { PurchaseHistoryRepositoryInterface } from '@/interfaces/PurchaseHistoryRepositoryInterface';
-  import type { CartProductEntry } from '@/interfaces/ProductEntry';
-
+import type { RateRepositoryInterface } from '@/interfaces/RateRepositoryInterface';
+import type { TranslateRepositoryInterface } from '@/interfaces/TranslateRepositoryInterface';
+import type { PurchaseHistoryRepositoryInterface } from '@/interfaces/PurchaseHistoryRepositoryInterface';
+import type { CartProductEntry } from '@/interfaces/ProductEntry';
+import { createTranslateRepository } from '@/factories/translateRepositoryFactory';
 
 const props = withDefaults(defineProps<{
     rateRepository?: RateRepositoryInterface;
@@ -22,7 +21,7 @@ const props = withDefaults(defineProps<{
   }>(), {
     rateRepository: () => new ApiRateRepository(),
     purchaseHistoryRepository: () => new LocalStoragePurchaseHistoryRepository(),
-    translateRepository: () => new ApiTranslateRepository(),
+    translateRepository: () => createTranslateRepository(),
   });
 
   const productRepositoryStore = useProductRepositoryStore();
@@ -52,33 +51,33 @@ const props = withDefaults(defineProps<{
 
   const updateCartItems = async () => {
     const newCartStoreItems = [...cartStore.cartItems];
-      const updatedCartItems: Array<CartProductEntry> = [];
+    const updatedCartItems: Array<CartProductEntry> = [];
 
-      for (const storeItem of newCartStoreItems) {
-        const existing: CartProductEntry | undefined = cartItems.value.find(cartItem => cartItem.product.id === storeItem.productId);
-        if (existing) {
-          existing.quantity = storeItem.quantity;
-          updatedCartItems.push(existing);
-        } else {
+    for (const storeItem of newCartStoreItems) {
+      const existing: CartProductEntry | undefined = cartItems.value.find(cartItem => cartItem.product.id === storeItem.productId);
+      if (existing) {
+        existing.quantity = storeItem.quantity;
+        updatedCartItems.push(existing);
+      } else {
         const product: Product | null = await productRepositoryStore.productRepository.getProductById(storeItem.productId);
-          if (product === null) {
-            throw new Error('カート内の商品情報が得られませんでした。');
-          }
-          updatedCartItems.push({
-            product: {
-              id: product.id,
-              title: product.title,
-              price: product.price,
-              description: product.description,
-              category: product.category,
-              image: product.image
-            },
-            quantity: storeItem.quantity,
-            deletedAt: null
-          });
+        if (product === null) {
+          throw new Error('カート内の商品情報が得られませんでした。');
         }
+        updatedCartItems.push({
+          product: {
+            id: product.id,
+            title: product.title,
+            price: product.price,
+            description: product.description,
+            category: product.category,
+            image: product.image
+          },
+          quantity: storeItem.quantity,
+          deletedAt: null
+        });
       }
-      cartItems.value = updatedCartItems;
+    }
+    cartItems.value = updatedCartItems;
   }
 
   onMounted(async () => {

--- a/src/views/CartView.vue
+++ b/src/views/CartView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
   import { ref, onMounted, computed, watch } from 'vue';
-  import { ApiProductRepository } from '@/repositories/ApiProductRepository';
   import { ApiRateRepository } from '@/repositories/ApiRateRepository';
   import { ApiTranslateRepository } from '@/repositories/ApiTranslateRepository';
   import { LocalStoragePurchaseHistoryRepository } from '@/repositories/LocalStoragePurchaseHistoryRepository';
@@ -8,7 +7,8 @@
   import { convertToYen } from '@/utils/priceFormatter';
   import { useCartStore } from '@/stores/UseCartStore';
   import { usePurchaseHistoryStore } from '@/stores/UsePurchaseHistoryStore';
-  import type { Product, ProductRepositoryInterface } from '@/interfaces/ProductRepositoryInterface';
+import { useProductRepositoryStore } from '@/stores/UseProductRepositoryStore';
+import type { Product } from '@/interfaces/ProductRepositoryInterface';
   import type { RateRepositoryInterface } from '@/interfaces/RateRepositoryInterface';
   import type { TranslateRepositoryInterface } from '@/interfaces/TranslateRepositoryInterface';
   import type { PurchaseHistoryRepositoryInterface } from '@/interfaces/PurchaseHistoryRepositoryInterface';
@@ -16,17 +16,16 @@
 
 
 const props = withDefaults(defineProps<{
-    productRepository?: ProductRepositoryInterface;
     rateRepository?: RateRepositoryInterface;
     purchaseHistoryRepository?: PurchaseHistoryRepositoryInterface;
     translateRepository?: TranslateRepositoryInterface;
   }>(), {
-    productRepository: () => new ApiProductRepository(),
     rateRepository: () => new ApiRateRepository(),
     purchaseHistoryRepository: () => new LocalStoragePurchaseHistoryRepository(),
     translateRepository: () => new ApiTranslateRepository(),
   });
 
+  const productRepositoryStore = useProductRepositoryStore();
   const rateStore = useRateStore();
   const cartStore = useCartStore();
   const purchaseHistoryStore = usePurchaseHistoryStore();
@@ -51,30 +50,17 @@ const props = withDefaults(defineProps<{
     cartItems.value = [];
   }
 
-  onMounted(async () => {
-    try {
-      await rateStore.initializeRate(props.rateRepository);
-      if (rateStore.jpyRate === null) {
-        throw new Error('JPYレートが取得できませんでした。');
-      }
-    } catch (e: any) {
-      error.value = e.message;
-    } finally {
-      loading.value = false;
-    }
-  });
-
-  watch(
-    () => [...cartStore.cartItems],
-    async newCartStoreItems => {
+  const updateCartItems = async () => {
+    const newCartStoreItems = [...cartStore.cartItems];
       const updatedCartItems: Array<CartProductEntry> = [];
+
       for (const storeItem of newCartStoreItems) {
         const existing: CartProductEntry | undefined = cartItems.value.find(cartItem => cartItem.product.id === storeItem.productId);
         if (existing) {
           existing.quantity = storeItem.quantity;
           updatedCartItems.push(existing);
         } else {
-          const product: Product | null = await props.productRepository.getProductById(storeItem.productId);
+        const product: Product | null = await productRepositoryStore.productRepository.getProductById(storeItem.productId);
           if (product === null) {
             throw new Error('カート内の商品情報が得られませんでした。');
           }
@@ -93,9 +79,23 @@ const props = withDefaults(defineProps<{
         }
       }
       cartItems.value = updatedCartItems;
-    },
-    {immediate: true, deep: true}
-  );
+  }
+
+  onMounted(async () => {
+    try {
+      await rateStore.initializeRate(props.rateRepository);
+      if (rateStore.jpyRate === null) {
+        throw new Error('JPYレートが取得できませんでした。');
+      }
+    } catch (e: any) {
+      error.value = e.message;
+    } finally {
+      loading.value = false;
+    }
+  });
+
+  watch(() => [...cartStore.cartItems],updateCartItems,{immediate: true, deep: true});
+  watch(() => productRepositoryStore.productRepository, updateCartItems);
 </script>
 
 <template>

--- a/src/views/CartView.vue
+++ b/src/views/CartView.vue
@@ -86,6 +86,7 @@ const props = withDefaults(defineProps<{
       if (rateStore.jpyRate === null) {
         throw new Error('JPYレートが取得できませんでした。');
       }
+      await updateCartItems();
     } catch (e: any) {
       error.value = e.message;
     } finally {

--- a/src/views/ProductDetailView.vue
+++ b/src/views/ProductDetailView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue';
+import { ref, onMounted } from 'vue';
 import { ApiRateRepository } from '@/repositories/ApiRateRepository';
 import { LocalStoragePurchaseHistoryRepository } from '@/repositories/LocalStoragePurchaseHistoryRepository';
 import { createTranslateRepository } from '@/factories/translateRepositoryFactory'

--- a/src/views/ProductDetailView.vue
+++ b/src/views/ProductDetailView.vue
@@ -1,32 +1,31 @@
 <script setup lang="ts">
-  import { ref, onMounted } from 'vue';
-  import { ApiProductRepository } from '@/repositories/ApiProductRepository';
-  import { ApiRateRepository } from '@/repositories/ApiRateRepository';
-  import { LocalStoragePurchaseHistoryRepository } from '@/repositories/LocalStoragePurchaseHistoryRepository';
-  import { createTranslateRepository } from '@/factories/translateRepositoryFactory'
-  import { useRateStore } from '@/stores/UseRateStore';
-  import{ useRoute } from 'vue-router';
-  import { convertToYen } from '@/utils/priceFormatter';
-  import { useCartStore } from '@/stores/UseCartStore';
-  import { usePurchaseHistoryStore } from '@/stores/UsePurchaseHistoryStore';
-  import Toast from '@/components/commom/Toast.vue';
-  import type { Product, ProductRepositoryInterface } from '@/interfaces/ProductRepositoryInterface';
-  import type { RateRepositoryInterface } from '@/interfaces/RateRepositoryInterface';
-  import type { PurchaseHistoryRepositoryInterface } from '@/interfaces/PurchaseHistoryRepositoryInterface';
-  import type { TranslateRepositoryInterface } from '@/interfaces/TranslateRepositoryInterface';
+import { ref, onMounted, watch } from 'vue';
+import { ApiRateRepository } from '@/repositories/ApiRateRepository';
+import { LocalStoragePurchaseHistoryRepository } from '@/repositories/LocalStoragePurchaseHistoryRepository';
+import { createTranslateRepository } from '@/factories/translateRepositoryFactory'
+import { useRateStore } from '@/stores/UseRateStore';
+import{ useRoute } from 'vue-router';
+import { convertToYen } from '@/utils/priceFormatter';
+import { useCartStore } from '@/stores/UseCartStore';
+import { usePurchaseHistoryStore } from '@/stores/UsePurchaseHistoryStore';
+import Toast from '@/components/commom/Toast.vue';
+import type { Product } from '@/interfaces/ProductRepositoryInterface';
+import type { RateRepositoryInterface } from '@/interfaces/RateRepositoryInterface';
+import type { PurchaseHistoryRepositoryInterface } from '@/interfaces/PurchaseHistoryRepositoryInterface';
+import type { TranslateRepositoryInterface } from '@/interfaces/TranslateRepositoryInterface';
+import { useProductRepositoryStore } from '@/stores/UseProductRepositoryStore';
 
   const props = withDefaults(defineProps<{
-    productRepository?: ProductRepositoryInterface;
     rateRepository?: RateRepositoryInterface;
     purchaseHistoryRepository?: PurchaseHistoryRepositoryInterface;
     translateRepository?: TranslateRepositoryInterface;
   }>(), {
-    productRepository: () => new ApiProductRepository(),
     rateRepository: () => new ApiRateRepository(),
     purchaseHistoryRepository: () => new LocalStoragePurchaseHistoryRepository(),
     translateRepository: () => createTranslateRepository(),
   });
 
+  const productRepositoryStore = useProductRepositoryStore();
   const route = useRoute();
   const product = ref<Product | null>(null);
   const loading = ref(true);
@@ -61,7 +60,9 @@
     showCartToast("購入しました", event.clientX, event.clientY);
   }
 
-  onMounted(async () => {
+  const fetchProductDetail = async () => {
+    loading.value = true;
+    error.value = null;
     try {
       await rateStore.initializeRate(props.rateRepository);
       if (rateStore.jpyRate === null) {
@@ -69,7 +70,7 @@
       }
       rate.value = rateStore.jpyRate;
       const productId = Number(route.params.id);
-      product.value = await props.productRepository.getProductById(productId);
+      product.value = await productRepositoryStore.productRepository.getProductById(productId);
       if (product.value === null) {
         throw new Error('商品が見つかりませんでした。');
       }
@@ -94,7 +95,11 @@
     } finally {
       loading.value = false;
     }
-  });
+  };
+
+  onMounted(fetchProductDetail);
+
+  watch(productRepositoryStore.productRepository, fetchProductDetail);
 </script>
 
 <template>

--- a/src/views/ProductDetailView.vue
+++ b/src/views/ProductDetailView.vue
@@ -98,8 +98,6 @@ import { useProductRepositoryStore } from '@/stores/UseProductRepositoryStore';
   };
 
   onMounted(fetchProductDetail);
-
-  watch(productRepositoryStore.productRepository, fetchProductDetail);
 </script>
 
 <template>

--- a/src/views/ProductListView.vue
+++ b/src/views/ProductListView.vue
@@ -7,6 +7,7 @@ import { useRouter } from 'vue-router';
 import { ApiRateRepository } from '@/repositories/ApiRateRepository';
 import { useRateStore } from '@/stores/UseRateStore';
 import { useProductRepositoryStore } from '@/stores/UseProductRepositoryStore';
+import { useCartStore } from '@/stores/UseCartStore';
 
 const props = withDefaults(defineProps<{
   rateRepository?: RateRepositoryInterface;
@@ -14,6 +15,7 @@ const props = withDefaults(defineProps<{
   rateRepository: () => new ApiRateRepository()
 });
 
+const cartStore = useCartStore();
 const productRepositoryStore = useProductRepositoryStore();
 const products = ref<Product[]>([]);
 const loading = ref(true);
@@ -44,12 +46,23 @@ const fetchProducts = async () => {
   }
 };
 
-onMounted(fetchProducts);
+const switchProductRepository = () => {
+  if(confirm("カート内の商品は全て削除されます。切り替えを実行しますか？")) {
+    cartStore.clearCart();
+    productRepositoryStore.toggleProductRepository();
+    fetchProducts();
+  }
+};
 
-watch(() => productRepositoryStore.productRepository, fetchProducts);
+onMounted(fetchProducts);
 </script>
 
 <template>
+  <header>
+    <button @click="switchProductRepository">
+      {{ productRepositoryStore.isUseStub ? '本番商品APIに切り替え' : '商品スタブに切り替え' }}
+    </button>
+  </header>
   <main>
     <h1>商品一覧</h1>
     <div v-if="loading" class="message">商品データ読み込み中...</div>

--- a/src/views/ProductListView.vue
+++ b/src/views/ProductListView.vue
@@ -8,6 +8,7 @@ import { ApiRateRepository } from '@/repositories/ApiRateRepository';
 import { useRateStore } from '@/stores/UseRateStore';
 import { useProductRepositoryStore } from '@/stores/UseProductRepositoryStore';
 import { useCartStore } from '@/stores/UseCartStore';
+import ConfirmDialog from '@/components/commom/ConfirmDialog.vue';
 
 const props = withDefaults(defineProps<{
   rateRepository?: RateRepositoryInterface;
@@ -23,6 +24,7 @@ const error = ref<string | null>(null);
 const router = useRouter();
 const rateStore = useRateStore();
 const rate = ref<number>(0);
+const showConfirmDialog = ref(false);
 
 const handleDetailClick = (productId: number) => {
   router.push(`/product/${productId}`);
@@ -46,12 +48,19 @@ const fetchProducts = async () => {
   }
 };
 
-const switchProductRepository = () => {
-  if(confirm("カート内の商品は全て削除されます。切り替えを実行しますか？")) {
-    cartStore.clearCart();
-    productRepositoryStore.toggleProductRepository();
-    fetchProducts();
-  }
+const handleShowConfirmDialog = () => {
+  showConfirmDialog.value = true;
+};
+
+const executeRepositorySwitch = () => {
+  showConfirmDialog.value = false;
+  cartStore.clearCart();
+  productRepositoryStore.toggleProductRepository();
+  fetchProducts();
+};
+
+const cancelRepositorySwitch = () => {
+  showConfirmDialog.value = false;
 };
 
 onMounted(fetchProducts);
@@ -59,7 +68,7 @@ onMounted(fetchProducts);
 
 <template>
   <header>
-    <button @click="switchProductRepository">
+    <button @click="handleShowConfirmDialog">
       {{ productRepositoryStore.isUseStub ? '本番商品APIに切り替え' : '商品スタブに切り替え' }}
     </button>
   </header>
@@ -75,6 +84,13 @@ onMounted(fetchProducts);
         <button @click="handleDetailClick(product.id)">詳細を見る</button>
       </div>
     </div>
+    <ConfirmDialog
+      v-if="showConfirmDialog"
+      :isDialogVisible="showConfirmDialog"
+      dialogMessage="カート内の商品は全て削除されます。切り替えを実行しますか？"
+      @confirm="executeRepositorySwitch"
+      @cancel="cancelRepositorySwitch"
+    />
   </main>
 </template>
 

--- a/src/views/ProductListView.vue
+++ b/src/views/ProductListView.vue
@@ -1,21 +1,20 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
-import type { Product, ProductRepositoryInterface } from '@/interfaces/ProductRepositoryInterface';
+import { ref, onMounted, watch } from 'vue';
+import type { Product } from '@/interfaces/ProductRepositoryInterface';
 import type { RateRepositoryInterface } from '@/interfaces/RateRepositoryInterface';
-import { ApiProductRepository } from '@/repositories/ApiProductRepository';
 import { convertToYen } from '@/utils/priceFormatter';
 import { useRouter } from 'vue-router';
 import { ApiRateRepository } from '@/repositories/ApiRateRepository';
 import { useRateStore } from '@/stores/UseRateStore';
+import { useProductRepositoryStore } from '@/stores/UseProductRepositoryStore';
 
 const props = withDefaults(defineProps<{
-  productRepository?: ProductRepositoryInterface;
   rateRepository?: RateRepositoryInterface;
 }>(), {
-  productRepository: () => new ApiProductRepository(),
   rateRepository: () => new ApiRateRepository()
 });
 
+const productRepositoryStore = useProductRepositoryStore();
 const products = ref<Product[]>([]);
 const loading = ref(true);
 const error = ref<string | null>(null);
@@ -27,21 +26,27 @@ const handleDetailClick = (productId: number) => {
   router.push(`/product/${productId}`);
 }
 
-onMounted(async () => {
+const fetchProducts = async () => {
+  loading.value = true;
+  error.value = null;
   try {
     await rateStore.initializeRate(props.rateRepository);
     if (rateStore.jpyRate === null) {
       throw new Error('JPYレートが取得できませんでした。');
     }
     rate.value = rateStore.jpyRate;
-    const response = await props.productRepository.getAllProducts();
+    const response = await productRepositoryStore.productRepository.getAllProducts();
     products.value = response;
   } catch (e: any) {
     error.value = e.message;
   } finally {
     loading.value = false;
   }
-})
+};
+
+onMounted(fetchProducts);
+
+watch(() => productRepositoryStore.productRepository, fetchProducts);
 </script>
 
 <template>

--- a/src/views/ProductListView.vue
+++ b/src/views/ProductListView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue';
+import { ref, onMounted } from 'vue';
 import type { Product } from '@/interfaces/ProductRepositoryInterface';
 import type { RateRepositoryInterface } from '@/interfaces/RateRepositoryInterface';
 import { convertToYen } from '@/utils/priceFormatter';


### PR DESCRIPTION
## 変更点

- 商品取得処理用のスタブを用意した
　- 商品データは仮のものを用意した
　- 通信失敗や遅延ケースを想定できるような実装とした
- 画面上にボタンを用意し、ボタン押下でFake Store APIからのデータ取得とスタブからのデータ取得を切り替えられるようにした
- ボタン押下で切り替わるのは商品取得処理用APIのみとした